### PR TITLE
Add mono6 extension and patch inkjs-compatible inklecate

### DIFF
--- a/com.inklestudios.Inky.json
+++ b/com.inklestudios.Inky.json
@@ -5,6 +5,9 @@
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.mono6"
+    ],
     "command": "inky",
     "separate-locales": false,
     "finish-args": [
@@ -14,6 +17,13 @@
         "--filesystem=home"
     ],
     "modules": [
+        {
+            "name": "mono6",
+            "buildsystem": "simple",
+            "build-commands": [
+                "/usr/lib/sdk/mono6/install.sh"
+            ]
+        },
         {
             "name": "inky",
             "buildsystem": "simple",
@@ -29,6 +39,10 @@
                     "only-arches": [
                         "x86_64"
                     ]
+                },
+                {
+                    "type": "patch",
+                    "path": "inklecate_linux.patch"
                 }
             ]
         },


### PR DESCRIPTION
This is to make the following export options work: "Export for web"
and "Export story.js only".

https://github.com/inkle/inky/issues/354