### PR TITLE
Update both Freedesktop runtime and Electron BaseApp to 23.08

### DIFF
--- a/com.inklestudios.Inky.json
+++ b/com.inklestudios.Inky.json
@@ -1,9 +1,9 @@
 {
     "app-id": "com.inklestudios.Inky",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "22.08",
+    "base-version": "23.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.mono6"


### PR DESCRIPTION
This tentative PR won't build on Buildbot at the moment because [org.freedesktop.Sdk.Extension.mono6](https://github.com/flathub/org.freedesktop.Sdk.Extension.mono6), which is a requirement for this app, has **not** got a new branch yet. I've already opened a PR for that extension (flathub/org.freedesktop.Sdk.Extension.mono6#25), but until that new branch is set up, the build _should_ fail. When that new branch is finally set up, we can rebuild the test build again and hopefully it _should_ work as before. For this reason, I've marked this PR as a draft.